### PR TITLE
AWS incident hygiene: scripts, docs, and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy to `.env` in this repo root (never commit `.env`).
+#   cp .env.example .env
+#
+# Used by `scripts/aws/*.sh` for incident response and account hygiene.
+# Prefer IAM roles / SSO for day-to-day work; long-lived keys belong only here if needed.
+
+# Option A (matches many internal scripts):
+AWS_KEY=
+AWS_SECRET=
+
+# Option B (standard AWS CLI / boto3 names — either set works in our shell scripts):
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@ node_modules/*/**
 node_modules/
 .DS_Store
 dump.rdb
+
+# Secrets and local AWS / IR material (never commit)
+.env
+.env.*
+!.env.example
+*.pem
+*.ppk
+secrets/
+credentials/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,45 @@
 ## Introduction 
 This is a project to help protect DAO members from the prevalent scam, impersonation and phishing attacks that are happening in the Web3 space
 
+This repository is also the **home for AWS account hygiene and incident-response helpers** (shell scripts under `scripts/aws/`, and dated write-ups under `docs/incidents/`). Phishing tooling and cloud abuse are different problems, but both belong under “defense” for the workspace.
+
+---
+
+## AWS account cleanup (scripts)
+
+EC2 SSH **key pairs are regional** (they are not scoped per Availability Zone). Cleanup scripts therefore iterate **AWS Regions**, not individual AZs.
+
+### Prerequisites
+
+- AWS CLI v2 installed and on `PATH`.
+- Credentials in **`./.env`** at the repo root (never commit — see **`.gitignore`** and **`.env.example`**). Supported variable names:
+  - `AWS_KEY` + `AWS_SECRET`, or
+  - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
+- Prefer **least-privilege IAM** over root keys. Root keys should be an emergency-only path.
+
+### Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/aws/delete_ec2_keypair_all_regions.sh` | Deletes a named EC2 key pair in **every region** where it exists. |
+
+Example:
+
+```bash
+cd /path/to/Cypher-Defense
+cp .env.example .env   # once, then edit with real values (do not commit)
+./scripts/aws/delete_ec2_keypair_all_regions.sh buatbelisdfgmsobilbaim
+```
+
+Related automation in **`market_research`** (still valid for EC2 instance sweeps):
+
+- `market_research/scripts/terminate_ec2_by_launch_keypair.py` — finds instances by **launch-time key pair name** across regions; loads **`Cypher-Defense/.env` first**, then `market_research/.env`.
+
+### Incident write-ups
+
+See **`docs/incidents/`** for dated analyses (e.g. AWS Trust & Safety reports, CloudTrail findings, corrective actions).
+
+---
 
 ## Use cases
 Allow members to flag and get warned on any of the following

--- a/docs/incidents/2026-04-13-aws-ec2-trust-safety-abuse.md
+++ b/docs/incidents/2026-04-13-aws-ec2-trust-safety-abuse.md
@@ -1,0 +1,82 @@
+# AWS Trust & Safety — EC2 outbound abuse (April 2026)
+
+**Account:** `767697632458`  
+**Primary region in report:** `us-west-2`  
+**Instance cited:** `i-023059e53e79e1dc3`  
+**AWS case (example):** `11760736376-1`  
+
+This note records what we observed, what we infer, and what we changed. It is **not** legal advice and **not** an exhaustive forensics report.
+
+---
+
+## 1. What AWS reported
+
+AWS indicated that an EC2 instance in `us-west-2` was associated with **outbound activity resembling unauthorized access attempts** to remote hosts. The sample log referenced **outgoing TCP to port 3389 (RDP)** toward a specific remote IP, and AWS applied a **mitigating block** on that path.
+
+Port **3389** is commonly associated with **Windows Remote Desktop**. Unexpected RDP scanning or lateral movement patterns from cloud VMs are a frequent abuse signal.
+
+---
+
+## 2. What CloudTrail showed (management events)
+
+Using CloudTrail in `us-west-2` (and corroborating where available):
+
+### 2.1 Suspicious control-plane pattern
+
+A sequence of API calls was performed from **source IP `45.61.128.156`**, with a **Python Boto3 / Botocore** user agent on **Linux**, using **root IAM credentials** (`arn:aws:iam::767697632458:root`) and access key **`AKIAIQYX7Z65F25NMY6A`**.
+
+Notable events included:
+
+- **`ImportKeyPair`** for key pair name **`buatbelisdfgmsobilbaim`** (imported public key material; not an AWS-generated “download PEM” flow).
+- Multiple **`RunInstances`** attempts with the same AMI / key / security group context; some attempts failed with **`Client.VcpuLimitExceeded`**, followed by a successful **`RunInstances`** (response payload sometimes omitted in console lookup due to size limits).
+
+### 2.2 Cleanup / inspection pattern (separate key)
+
+Later activity from a **different** source IP consistent with **operator cleanup** (e.g. **`DescribeInstances`**, **`TerminateInstances`**) was associated with access key **`AKIA3FPSYHTFC532UEJO`** (still a **root** key in this account at the time of inspection).
+
+### 2.3 Interpretation
+
+The **`45.61.128.156` / AKIAIQYX7Z65F25NMY6A`** activity is consistent with **a leaked root access key** being used from an external host to **import an SSH key** and **launch EC2** in `us-west-2`.
+
+That is **not** the same as “the SSH key pair alone proves compromise,” but the **root long-lived key + imports + launches** is a high-severity control-plane indicator.
+
+---
+
+## 3. IAM state after review
+
+At the time of follow-up IAM inspection:
+
+- **`AKIAIQYX7Z65F25NMY6A`** was **not** present on any scanned IAM user and **not** listed among the account’s remaining **root access keys** → treated as **removed/inactive** (still rotate anything that could have been exposed and assume past misuse).
+- The account retained a **separate active root access key** used for legitimate operations — **root access keys should be eliminated** where possible in favor of **least-privilege IAM** with **MFA**.
+
+---
+
+## 4. Corrective actions (operator checklist)
+
+These are the actions we recommend documenting in replies to AWS Trust & Safety:
+
+1. **Disable and delete** unauthorized root access keys; **rotate** any credentials that may have appeared in repos, backups, or email.
+2. **Terminate** unknown instances; **delete** imported key pairs tied to the incident naming (`buatbelisdfgmsobilbaim`) across **all regions** (key pairs are regional).
+3. **Tighten security groups / NACLs**: default-deny egress where feasible; allow only required ports and destinations.
+4. **Turn on organization-wide or multi-region CloudTrail** with immutable storage where appropriate; enable **GuardDuty** and **AWS Config** for drift detection.
+5. **Remove secrets from source control** (search git history); use **SSM Parameter Store / Secrets Manager** and **IAM roles**, not root keys.
+6. **Review** `krake_ror` and any other repos for **hard-coded AWS keys** (separate finding during this incident response).
+
+---
+
+## 5. Repository hygiene (this monorepo)
+
+Going forward, **AWS incident-response credentials and cleanup scripts** should live under **`Cypher-Defense/`**:
+
+- Local secrets: **`Cypher-Defense/.env`** (gitignored).
+- Scripts: **`Cypher-Defense/scripts/aws/`** (safe to commit).
+
+**`market_research/.env`** should remain for marketing / research automation keys only, not long-lived cloud admin credentials.
+
+---
+
+## 6. References
+
+- [AWS Acceptable Use Policy](https://aws.amazon.com/aup/)
+- [EC2 security groups](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html)
+- [AWS Security best practices](https://docs.aws.amazon.com/security/)

--- a/scripts/aws/delete_ec2_keypair_all_regions.sh
+++ b/scripts/aws/delete_ec2_keypair_all_regions.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Delete a named EC2 key pair in every AWS Region where it exists.
+#
+# Note: EC2 key pairs are regional resources (not per Availability Zone).
+# This script enumerates all enabled regions and calls DeleteKeyPair per hit.
+#
+# Credentials: root `.env` in this repo (AWS_KEY/AWS_SECRET or standard AWS_* names),
+# or existing AWS_ACCESS_KEY_ID / AWS_PROFILE in the environment.
+#
+# Usage:
+#   ./scripts/aws/delete_ec2_keypair_all_regions.sh [key-name]
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KEY_NAME="${1:-buatbelisdfgmsobilbaim}"
+
+if [[ -f "$ROOT/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ROOT/.env"
+  set +a
+fi
+
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-${AWS_KEY:-${AWSKEY:-}}}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-${AWS_SECRET:-}}"
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  echo "Missing AWS credentials. Set them in $ROOT/.env (see .env.example) or export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY." >&2
+  exit 1
+fi
+
+echo "Caller identity:"
+aws sts get-caller-identity --output json
+echo
+echo "Scanning all regions for key pair name: ${KEY_NAME}"
+
+# macOS ships Bash 3.2 (no `mapfile`); build the region list portably.
+REGIONS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && REGIONS+=("$line")
+done < <(aws ec2 describe-regions --query 'Regions[].RegionName' --output text | tr '\t' '\n' | sort)
+
+deleted=0
+missing=0
+errors=0
+
+for region in "${REGIONS[@]}"; do
+  if aws ec2 describe-key-pairs --region "$region" --key-names "$KEY_NAME" --output text >/dev/null 2>&1; then
+    echo "[${region}] deleting ${KEY_NAME} ..."
+    if aws ec2 delete-key-pair --region "$region" --key-name "$KEY_NAME" --output text; then
+      deleted=$((deleted + 1))
+    else
+      errors=$((errors + 1))
+    fi
+  else
+    missing=$((missing + 1))
+  fi
+done
+
+echo
+echo "Summary: deleted=${deleted} (regions where key existed), no-match-regions=${missing}, errors=${errors}"


### PR DESCRIPTION
## Summary
- Add `scripts/aws/delete_ec2_keypair_all_regions.sh` to delete a named EC2 key pair in every AWS Region (key pairs are regional, not per-AZ).
- Add `docs/incidents/2026-04-13-aws-ec2-trust-safety-abuse.md` with CloudTrail-oriented analysis and corrective checklist.
- Extend `README.md` with an AWS cleanup section; add `.env.example` and tighten `.gitignore` so `.env` is never committed.

## Notes
No secrets are included in this PR.

Made with [Cursor](https://cursor.com)