### PR TITLE
AWS case reply: fill in operator location (Los Angeles, USA)

### DIFF
--- a/docs/aws-reports/2026-04-18-case-177613748700177-followup-reply.md
+++ b/docs/aws-reports/2026-04-18-case-177613748700177-followup-reply.md
@@ -23,7 +23,7 @@ AWS also asked us to confirm:
 - Location we are accessing the account from
 - List of IAM users with access and their locations
 
-Fill in the two bracketed fields (`[YOUR CITY, COUNTRY]`) before sending.
+Operator location filled in: Los Angeles, California, USA (no VPN).
 
 ---
 
@@ -79,7 +79,7 @@ pre-staging across regions. No instances were launched with any of them.
 3. ACCOUNT ACCESS DETAILS (as requested)
 ──────────────────────────────────────────────
 
-Location: We are accessing the account from [YOUR CITY, COUNTRY].
+Location: We are accessing the account from Los Angeles, California, USA.
 We are not using a VPN for routine account access.
 
 IAM users with active access keys in this account:


### PR DESCRIPTION
## Summary
- Replaces `[YOUR CITY, COUNTRY]` placeholder with Los Angeles, California, USA in the Apr 18 AWS case reply draft
- Updates operator note to reflect the location is filled in

## Test plan
- [x] Verified the draft now reads ready-to-send

🤖 Generated with [Claude Code](https://claude.com/claude-code)