### PR TITLE
Fill in operator location in May-27 AWS case reply

### DIFF
--- a/docs/aws-reports/2026-05-27-case-177613748700177-consolidated-reply.md
+++ b/docs/aws-reports/2026-05-27-case-177613748700177-consolidated-reply.md
@@ -124,12 +124,12 @@ users, roles, or security groups remaining in the account.
 2. ACCOUNT ACCESS DETAILS (per your May 20 request)
 ────────────────────────────────────────────
 
-- Location of password reset / account access: [Los Angeles, California, USA].
+- Location of password reset / account access: San Francisco, California, USA.
   We do not use a VPN for routine root or console access.
 
 - Users with access to the account and their locations (all operate from our own
   infrastructure; no third parties):
-    * Root holder (Gary Teh) — Los Angeles, California, USA
+    * Root holder (Gary Teh) — San Francisco, California, USA
     * IAM user "edgar_aws_billing_automation" — billing automation, us-east-1
     * IAM user "truesight_app" — application S3 access, us-east-1
     * IAM user "database_backup" — snapshot automation (created 2026-04-17), us-east-1


### PR DESCRIPTION
Sets the access location to San Francisco, California, USA (no VPN) in both spots of the case 177613748700177 reply draft — the one operator-input field. Everything else was already populated from the live sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)