### PR TITLE
Update root password date in May-27 AWS case reply

### DIFF
--- a/docs/aws-reports/2026-05-27-case-177613748700177-consolidated-reply.md
+++ b/docs/aws-reports/2026-05-27-case-177613748700177-consolidated-reply.md
@@ -145,7 +145,7 @@ users, roles, or security groups remaining in the account.
 - Root MFA: enabled and active.
 - Root access keys: none present (0).
 - Compromised key AKIAIQYX7Z65F25NMY6A: confirmed removed; not active anywhere.
-- Root password: changed 2026-04-15.
+- Root password: changed during remediation and most recently rotated 2026-05-15.
 
 We believe the account is fully remediated and all listed resources are confirmed
 authorized. We would appreciate confirmation that the temporary service


### PR DESCRIPTION
Live credential report shows the Nelanco root password was most recently rotated 2026-05-15 (the draft said 2026-04-15). Also confirmed AccountAccessKeysPresent=0 — no root access keys exist, so the reply's "(0)" line is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)