### PR TITLE
Fix AWS scan crash on mixed open_ports sort

### DIFF
--- a/scripts/security_scan/scan_aws_inventory.py
+++ b/scripts/security_scan/scan_aws_inventory.py
@@ -152,7 +152,13 @@ def scan_account(account_label):
 
         result["regions"][region] = region_data
 
-    result["totals"]["open_ports"] = sorted(all_open_ports)
+    # open_ports can mix ints with the string "any" (rules without a FromPort, e.g.
+    # protocol -1 all-traffic), so a plain sorted() raises TypeError. Order numeric ports
+    # first (ascending), then any non-int markers like "any".
+    result["totals"]["open_ports"] = sorted(
+        all_open_ports,
+        key=lambda p: (0, p) if isinstance(p, int) else (1, str(p)),
+    )
     return result
 
 


### PR DESCRIPTION
sorted() of open_ports crashed when a rule had no FromPort (string 'any' mixed with ints), blanking AWS inventory despite valid creds. Sort ints-first. Verified locally.