### PR TITLE
Monthly AMI backups of the two production DB EC2 instances

### DIFF
--- a/.github/workflows/snapshot_databases_ami.yml
+++ b/.github/workflows/snapshot_databases_ami.yml
@@ -1,0 +1,44 @@
+name: Monthly Database AMI Backup
+
+# Full bootable AMI backups of the two production DB EC2 instances in Nelanco
+# (seni_sql = Edgar/seni_ror PostgreSQL, krake_data = krake_ror data/DB). An AMI
+# captures the OS root + ALL attached volumes (incl. the external data disk) as
+# one consistent bootable image — the DR-restore path. Complements the
+# data-volume-only EBS snapshots in snapshot_databases.yml.
+#
+# NoReboot — never interrupts a live database (crash-consistent; PostgreSQL
+# recovers via WAL). Retains the newest 6 AMIs per instance and prunes older
+# ones + their snapshots.
+#
+# Secrets (Nelanco account 767697632458, which owns the instances):
+#   CYPHER_DEFENCE_AWS_KEY / CYPHER_DEFENCE_AWS_SECRET  (already set — same as
+#   snapshot_databases.yml)
+
+on:
+  schedule:
+    - cron: "0 4 1 * *"   # 04:00 UTC on the 1st (offset from the 02:00 EBS snapshot)
+  workflow_dispatch:
+    inputs:
+      retain:
+        description: "How many AMIs to keep per instance"
+        default: "6"
+
+jobs:
+  db-ami-backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install boto3
+
+      - name: Create database AMIs + prune old ones
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CYPHER_DEFENCE_AWS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CYPHER_DEFENCE_AWS_SECRET }}
+        run: |
+          python3 scripts/aws/snapshot_databases_ami.py --execute --retain "${{ github.event.inputs.retain || '6' }}"

--- a/scripts/aws/snapshot_databases_ami.py
+++ b/scripts/aws/snapshot_databases_ami.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Create periodic **AMI** backups of the two production database EC2 instances
+in the Nelanco account (us-east-1).
+
+Why AMI in addition to the EBS snapshots in ``snapshot_databases.py``: that
+sibling script snapshots only each box's **data volume**. An AMI captures the
+**whole instance** — OS root disk + *all* attached EBS volumes (including the
+external data disk) — as one consistent, **bootable** image, which is what the
+disaster-recovery path actually needs (launch a replacement DB host from the
+AMI, not hand-rebuild the OS and re-attach a bare data snapshot).
+
+Instances (update if ever replaced — same convention as snapshot_databases.py):
+    i-08ebe96afbc649a95  →  seni_sql    (Edgar / seni_ror PostgreSQL; data vol /dev/sdb 250 GiB)
+    i-07c76510b231d787f  →  krake_data  (krake_ror data / DB;          data vol /dev/sdf 100 GiB)
+
+``--no-reboot`` so a backup never interrupts a live database. The image is
+therefore **crash-consistent** (not application-quiesced) — fine for PostgreSQL,
+which recovers from a crash-consistent disk state via its WAL, exactly as it
+would after a power loss. This matches the existing EBS-snapshot behaviour.
+
+Retention is **per instance**: keep the newest ``--retain`` AMIs this script
+created for each instance (grouped by the ``Instance`` tag), deregistering older
+ones and deleting their backing snapshots.
+
+Auth: repo-root ``.env`` — ``CYPHER_DEFENCE_AWS_KEY/SECRET`` (the Nelanco
+account that owns these instances), falling back to standard ``AWS_*`` names.
+In GitHub Actions the same names are injected from repo secrets.
+
+Usage (dry-run lists what it would do)::
+
+    python3 scripts/aws/snapshot_databases_ami.py
+    python3 scripts/aws/snapshot_databases_ami.py --execute
+    python3 scripts/aws/snapshot_databases_ami.py --execute --retain 6
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    print("Install boto3: pip install boto3", file=sys.stderr)
+    raise SystemExit(1)
+
+REGION = "us-east-1"
+MANAGED_BY = "snapshot_databases_ami"
+DEFAULT_RETAIN = 6  # monthly cadence → ~6 months of restore points
+
+# instance_id → codebase label (mirrors snapshot_databases.py)
+INSTANCE_MAP: dict[str, str] = {
+    "i-08ebe96afbc649a95": "seni_sql",    # Edgar / seni_ror PostgreSQL
+    "i-07c76510b231d787f": "krake_data",  # krake_ror data / DB
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def apply_aws_dotenv() -> None:
+    """Load AWS creds from repo-root .env, preferring the Nelanco (cypher) key."""
+    try:
+        from dotenv import dotenv_values
+    except ImportError:
+        return
+    env_path = repo_root() / ".env"
+    if not env_path.is_file():
+        return
+    vals = {k: v for k, v in dotenv_values(env_path).items() if v not in (None, "")}
+
+    if vals.get("CYPHER_DEFENCE_AWS_KEY"):
+        os.environ["AWS_ACCESS_KEY_ID"] = str(vals["CYPHER_DEFENCE_AWS_KEY"]).strip()
+        os.environ["AWS_SECRET_ACCESS_KEY"] = str(vals["CYPHER_DEFENCE_AWS_SECRET"]).strip()
+        os.environ.pop("AWS_SESSION_TOKEN", None)
+        return
+    if not os.environ.get("AWS_ACCESS_KEY_ID"):
+        for k in ("AWS_ACCESS_KEY_ID", "AWS_KEY"):
+            if vals.get(k):
+                os.environ["AWS_ACCESS_KEY_ID"] = str(vals[k]).strip()
+                break
+    if not os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        for k in ("AWS_SECRET_ACCESS_KEY", "AWS_SECRET"):
+            if vals.get(k):
+                os.environ["AWS_SECRET_ACCESS_KEY"] = str(vals[k]).strip()
+                break
+
+
+def create_ami(ec2, instance_id: str, label: str, name: str, description: str) -> str:
+    resp = ec2.create_image(
+        InstanceId=instance_id,
+        Name=name,
+        Description=description,
+        NoReboot=True,
+        TagSpecifications=[
+            {"ResourceType": rt, "Tags": [
+                {"Key": "Name", "Value": name},
+                {"Key": "Project", "Value": "TrueSightDAO"},
+                {"Key": "Service", "Value": "database"},
+                {"Key": "Codebase", "Value": label},
+                {"Key": "Instance", "Value": instance_id},
+                {"Key": "ManagedBy", "Value": MANAGED_BY},
+            ]}
+            for rt in ("image", "snapshot")
+        ],
+    )
+    return resp["ImageId"]
+
+
+def prune_instance(ec2, instance_id: str, retain: int, execute: bool) -> list[str]:
+    """Per-instance retention: deregister AMIs beyond ``retain`` (newest first)
+    for this instance and delete their backing snapshots."""
+    resp = ec2.describe_images(Owners=["self"], Filters=[
+        {"Name": "tag:ManagedBy", "Values": [MANAGED_BY]},
+        {"Name": "tag:Instance", "Values": [instance_id]},
+    ])
+    images = sorted(resp.get("Images", []), key=lambda im: im["CreationDate"], reverse=True)
+    actions: list[str] = []
+    for im in images[retain:]:
+        ami_id = im["ImageId"]
+        snap_ids = [m["Ebs"]["SnapshotId"]
+                    for m in im.get("BlockDeviceMappings", [])
+                    if m.get("Ebs", {}).get("SnapshotId")]
+        actions.append(f"deregister {ami_id} ({im.get('Name')}) + snapshots {snap_ids}")
+        if not execute:
+            continue
+        try:
+            ec2.deregister_image(ImageId=ami_id)
+            for sid in snap_ids:
+                ec2.delete_snapshot(SnapshotId=sid)
+        except (ClientError, BotoCoreError) as e:
+            actions[-1] += f"  [ERROR: {e}]"
+    return actions
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Periodic AMI backups of the two production DB EC2 instances.")
+    p.add_argument("--execute", action="store_true",
+                   help="Create AMIs + prune. Without it, only describe.")
+    p.add_argument("--retain", type=int, default=DEFAULT_RETAIN,
+                   help=f"AMIs to keep per instance (default {DEFAULT_RETAIN}).")
+    args = p.parse_args()
+
+    apply_aws_dotenv()
+    if not os.environ.get("AWS_ACCESS_KEY_ID"):
+        print("No AWS credentials (set CYPHER_DEFENCE_AWS_KEY/SECRET).", file=sys.stderr)
+        return 1
+
+    ec2 = boto3.Session().client("ec2", region_name=REGION)
+    date_str = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M")
+    errors: list[str] = []
+
+    for instance_id, label in INSTANCE_MAP.items():
+        name = f"{label}_ami_{date_str}"
+        desc = f"Automated DB AMI backup of {label} ({instance_id}) - {MANAGED_BY}"
+        if not args.execute:
+            print(f"  [dry-run] {instance_id} ({label}) -> AMI {name}")
+            for a in prune_instance(ec2, instance_id, args.retain, execute=False):
+                print(f"  [dry-run]   would {a}")
+            continue
+        try:
+            ami_id = create_ami(ec2, instance_id, label, name, desc)
+            print(f"  created AMI {ami_id}  name={name}  instance={instance_id} ({label})  (NoReboot)")
+        except (ClientError, BotoCoreError) as e:
+            errors.append(f"{instance_id}/{label}: create-image failed — {e}")
+            continue
+        for a in prune_instance(ec2, instance_id, args.retain, execute=True):
+            print(f"  pruned: {a}")
+
+    if errors:
+        print("\nErrors:", file=sys.stderr)
+        for err in errors:
+            print(f"  {err}", file=sys.stderr)
+    if not args.execute:
+        print("\nDry-run only. Re-run with --execute to create AMIs.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Goal
Add full **AMI** (bootable image) backups of the two Nelanco database boxes — `seni_sql` (Edgar/seni_ror PostgreSQL) and `krake_data` (krake_ror data/DB) — both of which have an **external data disk** attached. Today they only get **data-volume EBS snapshots** (`snapshot_databases.py`), which don't capture the OS or produce a bootable image — so DR means hand-rebuilding the host and re-attaching a bare snapshot. An AMI captures OS root + all attached volumes (incl. the external disk) in one consistent set.

## Verified state (live AWS, Nelanco 767697632458)
| Instance | Name | External data disk |
|---|---|---|
| i-08ebe96afbc649a95 | seni_sql_2026 | /dev/sdb `vol-0dfe671e3d6254b08` (250 GiB) |
| i-07c76510b231d787f | krake_data | /dev/sdf `vol-0344926855e4fe8a2` (100 GiB) |
No automated AMI backup existed for either (only old ad-hoc manual AMIs).

## Changes
- **scripts/aws/snapshot_databases_ami.py** — `create_image(NoReboot=True)` for both instances, tags AMI + snapshots (`ManagedBy=snapshot_databases_ami`, `Instance=<id>`), **per-instance** retention prune (keep 6). Same dotenv/auth pattern as `snapshot_databases.py`; ASCII description (create-image rejects non-ASCII — learned from the autopilot AMI script).
- **.github/workflows/snapshot_databases_ami.yml** — monthly 1st 04:00 UTC (offset from the 02:00 EBS snapshot) + `workflow_dispatch`. Reuses existing `CYPHER_DEFENCE_AWS_*` secrets.

## Notes
- `--no-reboot` → crash-consistent (Postgres recovers via WAL), never interrupts a live DB — same posture as the existing EBS snapshots.
- Complements, does not replace, `snapshot_databases.py` (kept for the established monthly data-vol snapshots).

## Testing
Dry-run against live AWS resolved both instances + creds and planned the AMIs/prune. `py_compile` clean. First real run triggered via workflow_dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)